### PR TITLE
Remove wrong keyword 'filename' for LaTeX in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -294,7 +294,7 @@ Run the following in a Python interpreter in the netlist file directory:
     # Write ready-to-use .tex document
     phs.texdocument(content,
                     title='DLC',
-                    filename='dlc.tex')
+                    path='dlc.tex')
 
 
 This yields the following **tex** file:


### PR DESCRIPTION
Hi contributors,

There is a small error in the README, in the example code about LaTeX export. The argument 'filename' doesn't exists anymore. It is 'path' now.

I just changed the keyword for ` filename` to `path` in the code sample.