### PR TITLE
Setting C++11 standard globally

### DIFF
--- a/pyphs/numerics/cpp/cmake.py
+++ b/pyphs/numerics/cpp/cmake.py
@@ -36,6 +36,9 @@ def _template(project_name):
 # Specify the minimum version for CMake
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
+# Activate C++ 11
+set (CMAKE_CXX_STANDARD 11)
+
 # Project's name
 project(%s CXX)
 
@@ -61,6 +64,4 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 add_executable(%s ${SOURCE_FILES})
 target_link_libraries (%s Eigen3::Eigen)
 
-# Activate C++11
-target_compile_features(%s PUBLIC cxx_std_11)
-""" % (project_name, project_name, project_name, project_name)
+""" % (project_name, project_name, project_name)


### PR DESCRIPTION
According to this [blog post](https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/), setting the CMAKE_CXX_STANDARD is the simplest way of globally specifying the standard to use.
target_compile_features may be preferably intended to specify the standard for a given target (for example, in a large project, C+11 for some object file but not for others).

Considering that the standard is set globally in the C++ code generated by PyPHS and that this solves the issue https://github.com/pyphs/pyphs/issues/99 , this commit makes sense.