### PR TITLE
Correct bug in graph analysis

### DIFF
--- a/pyphs/__init__.py
+++ b/pyphs/__init__.py
@@ -27,7 +27,7 @@ __license__ = \
 __author__ = "Antoine Falaize"
 __maintainer__ = "Antoine Falaize"
 __copyright__ = "Copyright 2012-2017"
-__version__ = '0.3.1rc1'
+__version__ = '0.3.1rc2'
 __author_email__ = 'antoine.falaize@gmail.fr'
 
 __all__ = ['Core', 'Netlist', 'Simulation', 'Graph', 'datum',

--- a/pyphs/graphs/subgraph.py
+++ b/pyphs/graphs/subgraph.py
@@ -560,7 +560,7 @@ class SubGraphSerial(SubGraph):
             root = None
 
         # Convert graph type to undirected graph with no parallel edge.
-        simple_graph = nwxGraph(self.to_undirected())
+        simple_graph = nwxGraph(self)
 
         # Return chain decomposition
         return list(chain_decomposition(simple_graph,
@@ -633,7 +633,7 @@ determined\n{}'.format(e))
             if not ((n1, n2) in preserve_nodes or
                     (n2, n1) in preserve_nodes):
 
-                undirected = self.to_undirected()
+                undirected = nwxGraph(self)
 
                 if n1 in self.terminals:
                     del_node, connect_node1 = n2, n1

--- a/pyphs/graphs/tools.py
+++ b/pyphs/graphs/tools.py
@@ -36,7 +36,7 @@ def serial_next(graph, n1, n2, testDatum=True):
 
     """
     # Undirected graph
-    g = graph.to_undirected()
+    g = nx.Graph(graph)
 
     # Init list of nodes in the serial chain
     serial = [n1, n2]
@@ -74,9 +74,8 @@ def serial_edges(graph):
 
     """
     # Undirected graph only
-    nxgraph = nx.Graph()
-    nxgraph.add_edges_from(graph.edgeslist)
-    g = nxgraph.to_undirected()
+    g = nx.Graph(graph)
+
     # init lists
     serial_nodes = list()
     all_edges = list()
@@ -133,7 +132,8 @@ def parallel_edges(graph):
         parallel connection.
 
     """
-    g = graph.to_undirected()
+    g = nx.Graph(graph)
+
     all_edges = list()
     for node in g.nodes():
         if g.degree(node) > 1 and not node == datum:


### PR DESCRIPTION
Remove each occurence of 
"g = graph.to_undirected()"
Since it calls copy.deepcopy in the hood and this is not compatible with Sympy.
Use 
"g = networkx.Graph(graph) "
instead