### PR TITLE
Handling linear part of Hamiltonian of linear components

### DIFF
--- a/pyphs/core/core.py
+++ b/pyphs/core/core.py
@@ -139,6 +139,7 @@ class Core:
         # Coefficient matrices for linear parts
         self.setexpr('Q', types.matrix_types[0](sympy.zeros(0, 0)))
         self.setexpr('Zl', types.matrix_types[0](sympy.zeros(0, 0)))
+        self.setexpr('bl', types.matrix_types[0](sympy.zeros(0, 0)))
 
         # init tools
         self.dims = Dimensions(self)

--- a/pyphs/core/structure/splits.py
+++ b/pyphs/core/structure/splits.py
@@ -9,7 +9,7 @@ Created on Mon May 15 15:14:37 2017
 from .moves import (movematrixcols, movesquarematrixcolnrow,
                     move_stor, move_diss)
 from ..tools import free_symbols
-from ..maths import hessian, jacobian
+from ..maths import hessian, jacobian, matvecprod
 import sympy
 
 
@@ -61,7 +61,9 @@ def linear_nonlinear(core, criterion=None):
     1. Detect the number of linear storage component (_nxl) and of linear
     dissipative components (_nwl).
     2. Sort components as [linear, nonlinear].
-    3. Build matrices Q and Zl.
+    3. Build matrices Q, bl and Zl such as
+       H_l(x_l) = 1/2 x_l^T.Q.x_l + x_l^T.bl
+       Z_l(w_l) = Zl.wl
 
     Parameters
     ----------
@@ -119,7 +121,13 @@ def linear_nonlinear(core, criterion=None):
 
     # number of linear components
     setattr(core.dims, '_xl', nxl)
-    core.setexpr('Q', hessian(core.H, core.xl()))
+    # Hamiltonian of linear components
+    # Quadratic part
+    Q = hessian(core.H, core.xl())
+    # Linear part
+    bl = jacobian(core.H, core.xl()) - matvecprod(Q, core.xl())
+    core.setexpr('Q', Q)
+    core.setexpr('bl', bl)
 
     # number of linear components
     setattr(core.dims, '_wl', nwl)

--- a/pyphs/numerics/numerical_method/_method.py
+++ b/pyphs/numerics/numerical_method/_method.py
@@ -673,8 +673,9 @@ dictionary.
     # build discrete evaluation of the gradient
     if method.config['grad'] == 'discret':
         # discrete gradient
-        dxHl = list(types.matrix_types[0](method.Q)*(types.matrix_types[0](method.xl()) +
-                    0.5*types.matrix_types[0](method.dxl())))
+        mtype = types.matrix_types[0]
+        dxHl = list(mtype(method.Q)*(mtype(method.xl()) + 0.5*mtype(method.dxl()))
+                    + mtype(method.bl))
         dxHnl = discrete_gradient(method.H, method.xnl(), method.dxnl(),
                                   method.config['epsdg'])
         method._dxH = dxHl + dxHnl


### PR DESCRIPTION
Hi Antoine,
I spend some time digging into the numerical method in order to understand how a linear part in the Hamiltonian of linear components can be tackled, i.e. the bl part in the following expression:
$Hl(xl) = 1/2 x^T.Q.x + x^T.bl$

Once the vector `bl` is computed (in the linear_nonlinear splitting function), and only focusing in the discrete gradient method, the implementation is quite straightforward, as only dxHl needs to be modified.

Latex export and other numerical methods (theta and trapez) still have to be adapted.
Let me know if you are interested in this.