### PR TITLE
Using proper tolerance in the computation of discrete gradient

### DIFF
--- a/pyphs/config.py
+++ b/pyphs/config.py
@@ -59,6 +59,7 @@ DTYPE = numpy.finfo(float).dtype.type
 FS = 48e3
 
 # Define the numerical tolerance such that |x|<EPS <=> x = 0
+# Used in the Newton-Raphson method as a condition on convergence
 # EPS = numpy.finfo(float).eps    # numpy tolerance
 EPS = 1e-12                     # custom tolerance
 

--- a/pyphs/numerics/numerical_method/_discrete_calculus.py
+++ b/pyphs/numerics/numerical_method/_discrete_calculus.py
@@ -6,12 +6,12 @@ Created on Fri Jun  3 01:46:04 2016
 """
 from __future__ import absolute_import, division, print_function
 import sympy
-from pyphs.config import EPS
+from pyphs.config import EPS_DG
 from pyphs.core.tools import types
 from pyphs.core.maths import gradient
 
 
-def discrete_gradient(H, x, dx, numtol=EPS):
+def discrete_gradient(H, x, dx, numtol=EPS_DG):
     """
     Symbolic computation here. Return the discrete gradient of scalar function\
  H between x and x+dx, with H separable with respect to x: H = sum_i[H_i(x_i)].
@@ -51,8 +51,8 @@ def discrete_gradient(H, x, dx, numtol=EPS):
         Hpost = H.subs(x[i], x[i] + dx[i])
         dxh = (Hpost - H)/dx[i]
         dxh0 = H.diff(x[i]).doit()
-        dxhi = sympy.Piecewise((dxh, dx[i] < -(numtol**2)),
-                               (dxh0, dx[i] < numtol**2),
+        dxhi = sympy.Piecewise((dxh, dx[i] < -numtol),
+                               (dxh0, dx[i] < numtol),
                                (dxh, True))
         dxHd.append(dxhi)
     return dxHd


### PR DESCRIPTION
Hi there,
The `config.py` file contains two different epsilons:
* `EPS` that corresponds to the machine accuracy
* `EPS_DG` that corresponds to the tolerance under which we consider the continuous gradient instead of the discrete one.

However, in the computation of the discrete gradient, it is `EPS` that is imported, and `EPS**2` that is used in the `sympy.Piecewise` function.

Was there a reason for using `EPS**2`? It is way under the machine's precision.

Othewise, this should fix it.