### PR TITLE
Discrete gradient improvements

### DIFF
--- a/pyphs/config.py
+++ b/pyphs/config.py
@@ -65,7 +65,7 @@ EPS = 1e-12                     # custom tolerance
 
 # Define the numerical tolerance for the discrete gradient:
 # |dx|<EPS_DG <=> dxH = H'
-EPS_DG = numpy.finfo(float).eps
+EPS_DG = numpy.sqrt(numpy.finfo(float).eps)
 
 # Activate the use of theano for python numerical evaluations. This produce
 # code that need to be compiled with inherent time cost but faster evaluations.

--- a/pyphs/numerics/numerical_method/_discrete_calculus.py
+++ b/pyphs/numerics/numerical_method/_discrete_calculus.py
@@ -50,7 +50,8 @@ def discrete_gradient(H, x, dx, numtol=EPS_DG):
     for i in range(nx):
         Hpost = H.subs(x[i], x[i] + dx[i])
         dxh = (Hpost - H)/dx[i]
-        dxh0 = H.diff(x[i]).doit()
+        dxh_continuous = H.diff(x[i]).doit()
+        dxh0 = dxh_continuous  + 0.5 * dxh_continuous.diff(x[i]).doit()*dx[i]
         dxhi = sympy.Piecewise((dxh, dx[i] < -numtol),
                                (dxh0, dx[i] < numtol),
                                (dxh, True))


### PR DESCRIPTION
Hello dear PyPHS users,

### Problem statement
@FabricioS and I had difficulties simulating a non-linear physical systems where one of the state variables takes small values around its equilibrium (approx. 1e-8 around 0). The Newton-Raphson algorithm could not converge despite a well conditioned matrix.

Eventually we located the problem at the evaluation of the discrete gradient, which sufferered from:
1. Cancellation problem when the increment on the state variable dx tends towards 0 on the finite difference approximation
2. Discontinuity at the junction between the finite difference and the continuous approximation

Here is on an example, where parts of the curve is affected by these errors:
![dxH_zoom_problème_numérique_crop](https://user-images.githubusercontent.com/23525497/70140653-81181a00-1695-11ea-84b7-476f13c0ea6a.png)

### Proposed solution
The first point is solved to raise the tolerance from the machine's precision to its square root. Note that this tolerance is **problem dependent**. For instance in our physical system the tolerance has to be set at eps**0.4.

The second point it adressed by expending the continuous approximation of the gradient.

### How I tested it so far
I tested this PR on my particular problem (a non linear and conservative system).

More tests from other users should be performed. 


