### PR TITLE
Implement custom Vectors and Matrices

### DIFF
--- a/pyphs/__init__.py
+++ b/pyphs/__init__.py
@@ -36,6 +36,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from .core.tools._types import PHSMatrix, PHSSubArray
 from .core.core import Core
 from .graphs.graph import Graph
 from .graphs import datum

--- a/pyphs/core/core.py
+++ b/pyphs/core/core.py
@@ -491,24 +491,6 @@ class Core:
 
         i = attr.index(symb)
         return i
-#        try:
-#            print('try:')
-#            i = attr.get_index(symb)
-#            print(i)
-#        except AttributeError:
-#            # name and attribute type
-#            text = 'Attribute {} is not a list, it is a {}.'.format(name,
-#                                                                    type(attr))
-#            raise AttributeError(text)
-#
-#        except ValueError:
-#            # name and attribute type
-#            text = 'Attribute {} does not contain {}.'.format(name, symb)
-#            raise AttributeError(text)
-#        except:
-#            print('error')
-#        finally:
-#            return i
 
     # =========================================================================
 

--- a/pyphs/core/core.py
+++ b/pyphs/core/core.py
@@ -37,6 +37,14 @@ class Core:
     in PyPHS.
     """
 
+
+    # =====================================================================
+    # Retrieve custom types
+
+    Matrix = types.PHSMatrix
+    Vector = types.PHSVector
+    SubArray = types.PHSSubArray
+
     # =====================================================================
     # Retrieve structure methods
 
@@ -72,7 +80,6 @@ class Core:
 
         # =====================================================================
         # Label
-
         # Init label
         if label is None:
             label = 'phs'
@@ -109,7 +116,7 @@ class Core:
         self.exprs_names = set()
 
         # Init structure
-        self.M = types.matrix_types[0](sympy.zeros(0))
+        self.M = self.Matrix(sympy.zeros(0))
 
         # List of connectors
         self.connectors = list()
@@ -130,16 +137,16 @@ class Core:
 
         # init lists of symbols
         for name in {'x', 'w', 'u', 'y', 'cu', 'cy', 'p'}:
-            self.setsymb(name, types.vector_types[0]())
+            self.setsymb(name, self.Vector())
 
         # init functions
         self.setexpr('H', sympify(0))
-        self.setexpr('z', types.vector_types[0]())
+        self.setexpr('z', self.Vector())
 
         # Coefficient matrices for linear parts
-        self.setexpr('Q', types.matrix_types[0](sympy.zeros(0, 0)))
-        self.setexpr('Zl', types.matrix_types[0](sympy.zeros(0, 0)))
-        self.setexpr('bl', types.matrix_types[0](sympy.zeros(0, 0)))
+        self.setexpr('Q', self.Matrix(sympy.zeros(0, 0)))
+        self.setexpr('Zl', self.Matrix(sympy.zeros(0, 0)))
+        self.setexpr('bl', self.Matrix(sympy.zeros(0, 0)))
 
         # init tools
         self.dims = Dimensions(self)
@@ -325,7 +332,7 @@ class Core:
             for varj in core.dims.names:
                 Mij1 = getattr(core1, 'M'+vari+varj)()
                 Mij2 = getattr(core2, 'M'+vari+varj)()
-                Mij = types.matrix_types[0](sympy.diag(Mij1, Mij2))
+                Mij = core1.Matrix(sympy.diag(Mij1, Mij2))
                 if all(dim > 0 for dim in Mij.shape):
                     set_func = getattr(core, 'set_M'+vari+varj)
                     set_func(Mij)
@@ -376,10 +383,10 @@ class Core:
         is used in the numerical methods as the state increment
         :code:`x[n+1]=x[n]+dx[n]`.
         """
-        return [self.symbols('d'+str(x)) for x in self.x]
+        return self.Vector(*[self.symbols('d'+str(x)) for x in self.x])
 
     def dtx(self):
-        return [self.symbols('dt'+str(x)) for x in self.x]
+        return self.Vector(*[self.symbols('dt'+str(x)) for x in self.x])
 
     def b(self):
         return self.dtx() + self.w + self.y
@@ -417,7 +424,7 @@ class Core:
         for the discrete evaluation of Hamiltonian's gradient in the structure
         matrix and dissipation function z.
         """
-        return [self.symbols('g'+str(x)) for x in self.x]
+        return self.Vector(*[self.symbols('g'+str(x)) for x in self.x])
 
     def o(self):
         """
@@ -429,7 +436,7 @@ class Core:
         symbols for the discrete evaluation of observers in the structure
         matrix and dissipation function z.
         """
-        return list(self.observers.keys())
+        return self.Vector(*self.observers.keys())
 
     def setsymb(self, name, symbs):
         """
@@ -608,7 +615,7 @@ class Core:
         Initialize the structure matrix M with appropriate number of zeros.
 
         """
-        self.M = types.matrix_types[0](sympy.zeros(self.dims.tot()))
+        self.M = self.Matrix(sympy.zeros(self.dims.tot()))
 
     def J(self):
         """
@@ -817,14 +824,14 @@ add the connector'.format(i)
         Mswitch_list = [alpha * sympy.Matrix([[0, -1],
                                               [1, 0]])
                         for alpha in all_alpha]
-        Mswitch = types.matrix_types[0](sympy.diag(*Mswitch_list))
+        Mswitch = self.Matrix(sympy.diag(*Mswitch_list))
 
         nxwy = self.dims.x() + self.dims.w() + self.dims.y()
         # Gain matrix
         G_connectors = self.M[:nxwy, nxwy:]
         # Observation matrix
         O_connectors = self.M[nxwy:, :nxwy]
-        N_connectors = types.matrix_types[0](sympy.eye(self.dims.cy()) -
+        N_connectors = self.Matrix(sympy.eye(self.dims.cy()) -
                                              self.Mcycy() * Mswitch)
 
         try:
@@ -834,11 +841,11 @@ add the connector'.format(i)
             M_connectors = G_connectors*Mswitch*iN_connectors*O_connectors
 
             # Store new structure
-            self.M = types.matrix_types[0](self.M[:nxwy, :nxwy] + M_connectors)
+            self.M = self.Matrix(self.M[:nxwy, :nxwy] + M_connectors)
 
             # clean
-            setattr(self, 'cy', list())
-            setattr(self, 'cu', list())
+            setattr(self, 'cy', self.Vector())
+            setattr(self, 'cu', self.Vector())
             setattr(self, 'connectors', list())
 
         except ValueError:
@@ -868,15 +875,21 @@ add the connector'.format(i)
             Must be a valid storage function with respect to the state
             :math:`\\mathbf{x}` with :math:`\\nabla^2\\mahtrm H(\\mathbf{x}) \\succeq 0`.
         """
-        if isinstance(x, types.scalar_types):
-            x = [x, ]
-        elif isinstance(x, types.vector_types):
+
+        if isinstance(x, types.vector_types):
             pass
+        elif isinstance(x, types.scalar_types):
+            x = types.PHSVector(x)
+        elif hasattr(x, "__iter__"):
+            x = types.PHSVector(*x)
         else:
-            x_types = types.scalar_types+types.vector_types
-            raise TypeError('Type of x should be one of {}'.format(x_types))
+            raise TypeError('x should be a scalar or a vector, got {}'.format(x))
         types.scalar_test(H)
-        self.x += x
+
+
+        self._insert_rows_and_cols(self.dims.x(), len(x))
+
+        self.x = self.x + x
         self.H += H
 
     def add_dissipations(self, w, z):
@@ -900,17 +913,28 @@ add the connector'.format(i)
         :math:`\\mathbf{w}` with :math:`\\nabla\\mahtrm z(\\mathbf{w}) \succeq 0`.
         """
         if isinstance(w, types.vector_types):
-            types.vector_test(z)
+            pass
         elif isinstance(w, types.scalar_types):
-            types.scalar_test(z)
-            w = [w, ]
-            z = [z, ]
-            w_types = types.scalar_types+types.vector_types
+            w = types.PHSVector(w)
+        elif hasattr(w, "__iter__"):
+            w = types.PHSVector(*w)
         else:
-            text = 'Type of w and z should be one of {}'.format(w_types)
-            raise TypeError(text)
+            raise TypeError('w should be a scalar or a vector, got {}'.format(w))
+
+        if isinstance(z, types.vector_types):
+            pass
+        elif isinstance(z, types.scalar_types):
+            z = types.PHSVector(z)
+        elif hasattr(z, "__iter__"):
+            z = types.PHSVector(*z)
+        else:
+            raise TypeError('z should be a scalar or a vector, got {}'.format(z))
+
         if not len(w) == len(z):
             raise TypeError('w and z should have same dimension.')
+
+        self._insert_rows_and_cols(self.dims.x() + self.dims.w(), len(w))
+
         self.w += w
         self.z += z
 
@@ -933,18 +957,31 @@ add the connector'.format(i)
         y : one or several sympy.Expr
             Outputs symbols. Can be a single symbol or a list of symbols.
         """
+
         if isinstance(u, types.vector_types):
-            types.vector_test(y)
+            pass
         elif isinstance(u, types.scalar_types):
-            types.scalar_test(y)
-            u = [u, ]
-            y = [y, ]
-            y_types = types.scalar_types+types.vector_types
+            u = types.PHSVector(u)
+        elif hasattr(u, "__iter__"):
+            u = types.PHSVector(*u)
         else:
-            text = 'Type of u and y should be one of {}'.format(y_types)
-            raise TypeError(text)
+            raise TypeError('u should be a scalar or a vector, got {}'.format(u))
+
+
+        if isinstance(y, types.vector_types):
+            pass
+        elif isinstance(y, types.scalar_types):
+            y = types.PHSVector(y)
+        elif hasattr(y, "__iter__"):
+            y = types.PHSVector(*y)
+        else:
+            raise TypeError('y should be a scalar or a vector, got {}'.format(y))
+
         if not len(u) == len(y):
             raise TypeError('u and y should have same dimension.')
+
+        self._insert_rows_and_cols(self.dims.x() + self.dims.w(), len(u))
+
         self.u += u
         self.y += y
 
@@ -964,7 +1001,7 @@ add the connector'.format(i)
         if isinstance(p, types.vector_types):
             pass
         elif isinstance(p, types.scalar_types):
-            p = [p, ]
+            p = self.Vector(p)
         self.p += p
 
         for par in p:
@@ -984,6 +1021,16 @@ add the connector'.format(i)
             simulation at the begining of each time step.
         """
         self.observers.update(obs)
+
+
+    def _insert_rows_and_cols(self, idx, n):
+        # insert n rows and columns of zeros around self.M[idx, idx]
+        for i in range(n):
+            if self.M.shape[0] == 0:
+                self.M = self.Matrix([[0.0]])
+            else:
+                self.M = self.Matrix(self.M.col_insert(idx, self.Matrix([0]*(self.M.shape[0]))))
+                self.M = self.Matrix(self.M.row_insert(idx, self.Matrix([0]*(self.M.shape[1])).T))
 
     # =========================================================================
 
@@ -1052,12 +1099,12 @@ add the connector'.format(i)
 
         sympy.init_printing()
 
-        b = types.matrix_types[0](self.dtx() +
+        b = self.Matrix(self.dtx() +
                                   self.w +
                                   self.y +
                                   self.cy)
 
-        a = types.matrix_types[0](self.dxH() +
+        a = self.Matrix(self.dxH() +
                                   self.z +
                                   self.u +
                                   self.cu)
@@ -1069,7 +1116,7 @@ add the connector'.format(i)
     def to_evaluation(self, names='all', vectorize=True):
         """
         Return an object with all the numerical function associated with all
-        or a selected set of symbolic functions from a given pyphs.Core.
+        or a selected set of symbolic functions from a given pyphs.nnectre.
 
         Notice this is not a dynamical object, so it has to be rebuild if the
         original core object is changed in any way.
@@ -1255,9 +1302,9 @@ add the connector'.format(i)
         def set_mat(mat):
             vari, varj = dims_names
             if self.M.shape[0] != self.dims.tot():
-                self.M = types.matrix_types[0](sympy.zeros(self.dims.tot()))
+                self.M = self.Matrix(sympy.zeros(self.dims.tot()))
             if name == 'J':
-                Jab = types.matrix_types[0](mat)
+                Jab = self.Matrix(mat)
                 Rab = getattr(self, 'R'+vari + varj)()
                 Rba = getattr(self, 'R'+varj + vari)()
                 Mab = Jab - Rab
@@ -1265,17 +1312,17 @@ add the connector'.format(i)
             if name == 'R':
                 Jab = getattr(self, 'J'+vari + varj)()
                 Jba = getattr(self, 'J'+varj + vari)()
-                R = types.matrix_types[0](mat)
+                R = self.Matrix(mat)
                 Mab = Jab - R
                 Mba = Jba - R.T
             if name == 'M':
-                Mab = types.matrix_types[0](mat)
+                Mab = self.Matrix(mat)
                 Mba = getattr(self, 'M'+varj + vari)()
             debi, endi = getattr(self.inds, vari)()
             debj, endj = getattr(self.inds, varj)()
-            self.M[debi:endi, debj:endj] = types.matrix_types[0](Mab)
+            self.M[debi:endi, debj:endj] = self.Matrix(Mab)
             if vari != varj:
-                self.M[debj:endj, debi:endi] = types.matrix_types[0](Mba)
+                self.M[debj:endj, debi:endi] = self.Matrix(Mba)
         set_mat.__doc__ = """
         =========
         set_{0}{1}{2}
@@ -1308,7 +1355,7 @@ add the connector'.format(i)
 
         def l_accessor():
             dim = getattr(self.dims, dim_label+'l')()
-            return geteval(self, name)[:dim]
+            return self.Vector(*geteval(self, name)[:dim])
         l_accessor.__doc__ = """
     =====
     {0}l

--- a/pyphs/core/maths/_calculus.py
+++ b/pyphs/core/maths/_calculus.py
@@ -45,7 +45,7 @@ def gradient(scalar_func, vars_, simplify=False):
         grad[i] = scalar_func.diff(vars_[i]).doit()
     if simplify:
         grad = simplify_func(grad)
-    return grad
+    return types.PHSVector(*grad)
 
 
 def hessian(scalar_func, vars_, simplify=False):
@@ -112,7 +112,7 @@ def jacobian(func, vars_, simplify=False):
     types.vector_test(vars_)
     types.vector_test(func)
     nv, nf = len(vars_), len(func)
-    Jac = types.matrix_types[0](sympy.zeros(nf, nv))
+    Jac = types.PHSMatrix(sympy.zeros(nf, nv))
     for i in range(nf):
         for j in range(nv):
             Jac[i, j] = func[i].diff(vars_[j]).doit()

--- a/pyphs/core/maths/_matrices.py
+++ b/pyphs/core/maths/_matrices.py
@@ -40,9 +40,7 @@ def matvecprod(mat, vec):
         raise IndexError(text.format((m, n), l))
 
     if l == 0:
-        res = [0,]*m
+        res = types.PHSVector(*([0,]*m))
     else:
-        res = list(mat * Matrix(vec))
-#        if m == 1:
-#            res = [res, ]
+        res = types.PHSVector(*(mat * Matrix(vec)))
     return res

--- a/pyphs/core/maths/_vectors.py
+++ b/pyphs/core/maths/_vectors.py
@@ -20,4 +20,4 @@ sums vectors (list elements)
         types.vector_test(v)
         assert len(v) == l, '{} not equal to {}'.format(len(v), l)
         v0 = [e1 + e2 for e1, e2 in zip(v0, v)]
-    return v0
+    return types.PHSVector(*v0)

--- a/pyphs/core/structure/connectors.py
+++ b/pyphs/core/structure/connectors.py
@@ -35,8 +35,8 @@ No output (inplace change of the Core)
     moveCoreMcolnrow(core, core.dims.x()+core.dims.w()+i, core.dims.tot())
 
     # append port symbols to the list of connectors symbols
-    core.cu += [core.u[i], ]
-    core.cy += [core.y[i], ]
+    core.cu += core.Vector(core.u[i])
+    core.cy += core.Vector(core.y[i])
 
     # remove symbols from the list of port symbols
     for name in ['u', 'y']:

--- a/pyphs/core/structure/moves.py
+++ b/pyphs/core/structure/moves.py
@@ -93,9 +93,9 @@ def move_stor(core, indi, indf):
         Initial and final storage indices in the set of storages.
     """
     new_indices = myrange(core.dims.x(), indi, indf)
-    core.x = [core.x[el] for el in new_indices]
+    core.x = core.Vector(*(core.x[el] for el in new_indices))
     if core._dxH is not None:
-        core._dxH = [core._dxH[el] for el in new_indices]
+        core._dxH = core.Vector(*(core._dxH[el] for el in new_indices))
     moveCoreMcolnrow(core, indi, indf)
 
 
@@ -112,8 +112,8 @@ def move_diss(core, indi, indf):
         Initial and final dissipation indices in the set of dissipations.
     """
     new_indices = myrange(core.dims.w(), indi, indf)
-    core.w = [core.w[el] for el in new_indices]
-    core.z = [core.z[el] for el in new_indices]
+    core.w = core.Vector(*[core.w[el] for el in new_indices])
+    core.z = core.Vector(*[core.z[el] for el in new_indices])
     moveCoreMcolnrow(core, core.dims.x()+indi, core.dims.x()+indf)
     if (not core.Zl.is_zero and
             indi < core.dims.wl() and
@@ -136,8 +136,8 @@ def move_port(core, indi, indf):
         Initial and final port indices in the set of ports.
     """
     new_indices = myrange(core.dims.y(), indi, indf)
-    core.u = [core.u[el] for el in new_indices]
-    core.y = [core.y[el] for el in new_indices]
+    core.u = core.Vector(*[core.u[el] for el in new_indices])
+    core.y = core.Vector(*[core.y[el] for el in new_indices])
     moveCoreMcolnrow(core, core.dims.x()+core.dims.w()+indi,
                      core.dims.x()+core.dims.w()+indf)
 
@@ -155,7 +155,7 @@ def move_connector(core, indi, indf):
         Initial and final connector indices in the set of connectors.
     """
     new_indices = myrange(core.dims.cy(), indi, indf)
-    core.cu = [core.cu[el] for el in new_indices]
-    core.cy = [core.cy[el] for el in new_indices]
+    core.cu = core.Vector(*[core.cu[el] for el in new_indices])
+    core.cy = core.Vector(*[core.cy[el] for el in new_indices])
     moveCoreMcolnrow(core, core.dims.x()+core.dims.w()+core.dims.y()+indi,
                      core.dims.x()+core.dims.w()+core.dims.y()+indf)

--- a/pyphs/core/structure/output.py
+++ b/pyphs/core/structure/output.py
@@ -46,6 +46,6 @@ y: list
         out = list(Vyx + Vyw + Vyu)
 
     else:
-        out = types.matrix_types[0](list(list()))
+        out = list()
 
-    return list(out)
+    return types.PHSVector(*out)

--- a/pyphs/core/structure/splits.py
+++ b/pyphs/core/structure/splits.py
@@ -8,7 +8,7 @@ Created on Mon May 15 15:14:37 2017
 
 from .moves import (movematrixcols, movesquarematrixcolnrow,
                     move_stor, move_diss)
-from ..tools import free_symbols
+from ..tools import free_symbols, types
 from ..maths import hessian, jacobian, gradient, matvecprod
 import sympy
 
@@ -22,7 +22,7 @@ def monovar_multivar(core):
     i = 0
     for _ in range(core.dims.x()):
         hess = hessian(core.H, core.x)
-        hess_line = list(hess[i, :].T)
+        hess_line = types.PHSVector(*hess[i, :].T)
         # remove i-th element
         hess_line.pop(i)
         # if other elements are all 0
@@ -39,7 +39,7 @@ def monovar_multivar(core):
     # split dissipative part
     i = 0
     for _ in range(core.dims.w()):
-        Jacz_line = list(core.Jacz[i, :].T)
+        Jacz_line = types.PHSVector(*core.Jacz[i, :].T)
         # remove i-th element
         Jacz_line.pop(i)
         # if other elements are all 0
@@ -89,7 +89,7 @@ def linear_nonlinear(core, criterion=None):
     arg = criterion[0][1]
     for _ in range(hess.shape[1]):
         # hess_row = list(hess[nxl, :].T)
-        hess_col = list(hess[:, nxl])
+        hess_col = types.PHSVector(*hess[:, nxl])
         # collect line symbols
         symbs = free_symbols(hess_col)
         # if symbols are not states
@@ -107,7 +107,7 @@ def linear_nonlinear(core, criterion=None):
     arg = criterion[1][1]
     for _ in range(jacz.shape[1]):
         # jacz_row = list(jacz[nwl, :].T)
-        jacz_col = list(jacz[:, nwl])
+        jacz_col = types.PHSVector(*jacz[:, nwl])
         # collect line symbols
         symbs = free_symbols(jacz_col)
         # if symbols are not dissipation variables
@@ -125,7 +125,7 @@ def linear_nonlinear(core, criterion=None):
     # Quadratic part
     Q = hessian(core.H, core.xl())
     # Linear part
-    bl = [a-b for a, b in zip(gradient(core.H, core.xl()), matvecprod(Q, core.xl()))]
+    bl = core.Vector(*(a-b for a, b in zip(gradient(core.H, core.xl()), matvecprod(Q, core.xl()))))
 
     core.setexpr('Q', Q)
     core.setexpr('bl', bl)

--- a/pyphs/core/tools/_free_symbols.py
+++ b/pyphs/core/tools/_free_symbols.py
@@ -73,5 +73,5 @@ expr must be a sympy.SparseMatrix
     """
     types.matrix_test(mat)
     m, n = mat.shape
-    symbs = free_symbols_vec([e for (_, _, e) in mat.row_list()])
+    symbs = free_symbols_vec(types.PHSVector(*(e for (_, _, e) in mat.row_list())))
     return symbs

--- a/pyphs/core/tools/_simplify.py
+++ b/pyphs/core/tools/_simplify.py
@@ -144,9 +144,10 @@ vec_simp: same type as vec or str
     Simplified expressions if succeed, else returns 'not finished'
     """
     types.vector_test(vec)
-    for i, e in enumerate(vec):
-        vec[i] = simplify_scalar(e, **kwargs)
-    return 'not finished' if 'not finished' in vec else vec
+    temp = list(vec)
+    for i, e in enumerate(temp):
+        temp[i] = simplify_scalar(e, **kwargs)
+    return 'not finished' if 'not finished' in vec else types.PHSVector(*temp)
 
 
 def simplify_matrix(mat, **kwargs):

--- a/pyphs/core/tools/_subsinverse.py
+++ b/pyphs/core/tools/_subsinverse.py
@@ -55,13 +55,11 @@ def subsinverse_vector(expr, subs, symbols):
         The resulting expression.
     """
     # recast as list
-    if not isinstance(expr, types.vector_types[0]):
-        expr = types.vector_types[0](expr)
-
+    temp = list(expr)
     # iterate over list elements
-    for i, e in enumerate(expr):
-        expr[i] = subsinverse_scalar(e, subs, symbols)
-    return expr
+    for i, e in enumerate(temp):
+        temp[i] = subsinverse_scalar(e, subs, symbols)
+    return types.PHSVector(*temp)
 
 
 def subsinverse_matrix(expr, subs, symbols):

--- a/pyphs/core/tools/_substitutions.py
+++ b/pyphs/core/tools/_substitutions.py
@@ -59,13 +59,11 @@ def substitute_vector(expr, subs=None):
         The resulting expression.
     """
     # recast as list
-    if not isinstance(expr, types.vector_types[0]):
-        expr = types.vector_types[0](expr)
-
+    temp = list(expr)
     # iterate over list elements
-    for i, e in enumerate(expr):
-        expr[i] = substitute_scalar(e, subs)
-    return expr
+    for i, e in enumerate(temp):
+        temp[i] = substitute_scalar(e, subs)
+    return types.PHSVector(*temp)
 
 
 def substitute_matrix(expr, subs=None):

--- a/pyphs/core/tools/_types.py
+++ b/pyphs/core/tools/_types.py
@@ -54,6 +54,10 @@ def scalar_test(obj, metadata=(None, None)):
 
 class PHSVector(sympy.Tuple):
 
+    def __new__(cls, *args, **kwargs):
+        obj = sympy.Tuple.__new__(cls, *args)
+        return obj
+
     @property
     def has_subarray(self):
         all_types = set()
@@ -73,13 +77,13 @@ class PHSVector(sympy.Tuple):
         self._args = out
 
     def __add__(self, other):
-        return PHSVector(*super().__add__(other))
+        return PHSVector(*super(PHSVector, self).__add__(other))
 
     def __iadd__(self, other):
-        return PHSVector(*super().__add__(other))
+        return PHSVector(*super(PHSVector, self).__add__(other))
 
     def __getitem__(self, key):
-        item = super().__getitem__(key)
+        item = super(PHSVector, self).__getitem__(key)
         if hasattr(item, "__iter__"):
             return PHSVector(*item)
         else:
@@ -145,7 +149,7 @@ class PHSSubArray(sympy.Symbol):
 
         kwargs['commutative'] = False
 
-        obj = super().__new__(self, name, *args, **kwargs)
+        obj = super(PHSSubArray, self).__new__(self, name, *args, **kwargs)
 
         if attrs['shape'] is not None:
             obj._phs_array = None

--- a/pyphs/examples/sp_circuit/sp_circuit.py
+++ b/pyphs/examples/sp_circuit/sp_circuit.py
@@ -28,7 +28,5 @@ netlist = Netlist(netlist_filename)
 # Build Graph object
 graph = netlist.to_graph()
 
-graph.sp_split()
-
 # Build Core object
 core = graph.to_core(merge_all=True)

--- a/pyphs/graphs/build.py
+++ b/pyphs/graphs/build.py
@@ -37,6 +37,8 @@ def _select_relations(graph):
     select the dissipative relation 'z' and connectors coefficients 'alpha' \
 according to the control type of each indeterminate edge
     """
+
+    temp_z = list(graph.core.z)
     # select dissipative relations
     for e in graph.analysis.diss_edges:
 
@@ -47,15 +49,14 @@ according to the control type of each indeterminate edge
 
         if e in graph.analysis.ec_edges:
             # select effocrt-controlled constitutive law
-            graph.core.z[indw] = \
-                graph.analysis.get_edge_data(e, 'z')['e_ctrl']
+            temp_z[indw] = graph.analysis.get_edge_data(e, 'z')['e_ctrl']
         elif e in graph.analysis.fc_edges:
             # select flux-controlled constitutive law
-            graph.core.z[indw] = \
-                graph.analysis.get_edge_data(e, 'z')['f_ctrl']
+            temp_z[indw] = graph.analysis.get_edge_data(e, 'z')['f_ctrl']
         else:
-            message = "Control of edge {0} is not known."
+            message = "Control of edge {0} is not known.".format(label)
             raise ValueError(message)
+    graph.core.z = graph.core.Vector(*temp_z)
 
 
 def _setCore(graph):
@@ -66,7 +67,7 @@ def _setCore(graph):
         e_label = graph.analysis.get_edge_data(e, 'label')
         index_e_in_x = graph.core.x.index(e_label)
         new_indices_x.append(index_e_in_x)
-    graph.core.x = [graph.core.x[el] for el in new_indices_x]
+    graph.core.x = graph.core.Vector(*(graph.core.x[el] for el in new_indices_x))
 
     # sort dissipatives
     new_indices_w = []
@@ -74,8 +75,8 @@ def _setCore(graph):
         e_label = graph.analysis.get_edge_data(e, 'label')
         index_e_in_w = graph.core.w.index(e_label)
         new_indices_w.append(index_e_in_w)
-    graph.core.w = [graph.core.w[el] for el in new_indices_w]
-    graph.core.z = [graph.core.z[el] for el in new_indices_w]
+    graph.core.w = graph.core.Vector(*(graph.core.w[el] for el in new_indices_w))
+    graph.core.z = graph.core.Vector(*(graph.core.z[el] for el in new_indices_w))
 
     # sort sources
     new_indices_y = []
@@ -83,8 +84,8 @@ def _setCore(graph):
         e_label = graph.analysis.get_edge_data(e, 'label')
         index_e_in_y = graph.core.y.index(e_label)
         new_indices_y.append(index_e_in_y)
-    graph.core.y = [graph.core.y[el] for el in new_indices_y]
-    graph.core.u = [graph.core.u[el] for el in new_indices_y]
+    graph.core.y = graph.core.Vector(*(graph.core.y[el] for el in new_indices_y))
+    graph.core.u = graph.core.Vector(*(graph.core.u[el] for el in new_indices_y))
 
     # sort connectors
     new_indices_connector = []
@@ -96,8 +97,8 @@ def _setCore(graph):
         alpha = graph.analysis.get_edge_data(e, 'alpha')
         if alpha is not None:
             graph.core.connectors[index_e_in_connector]['alpha'] = alpha
-    graph.core.cy = [graph.core.cy[el] for el in new_indices_connector]
-    graph.core.cu = [graph.core.cu[el] for el in new_indices_connector]
+    graph.core.cy = graph.core.Vector(*(graph.core.cy[el] for el in new_indices_connector))
+    graph.core.cu = graph.core.Vector(*(graph.core.cu[el] for el in new_indices_connector))
 
     # select constitutive law (ec or fc) for dissipative components
     _select_relations(graph)

--- a/pyphs/graphs/graph.py
+++ b/pyphs/graphs/graph.py
@@ -132,8 +132,8 @@ class Graph(nx.MultiDiGraph):
             state of the analysis process. Default is False.
 
         solve_arc : bool (optional)
-            If True, the anti-realizable components are merged to produce a
-            realizable graph. Te default is True.
+            If True, the anti-realizable components (edges) are merged to
+            produce a realizable graph. The default is True.
 
         force : bool (optional)
             If False, the analysis is performed only if it has not been

--- a/pyphs/graphs/graph.py
+++ b/pyphs/graphs/graph.py
@@ -534,23 +534,19 @@ class Graph(nx.MultiDiGraph):
         """
         Apply subgraph.merge_all() for all subgraphs.
         """
-        subgraphs = self.sp_subgraphs
-        for label in subgraphs.keys():
-            try:
-                subgraphs[label].merge_all()
-            except AttributeError:
-                pass
+        for label in self.sp_subgraphs:
+            subgraph = self.sp_subgraphs[label]
+            if hasattr(subgraph, "merge_all"):
+                subgraph.merge_all()
 
     def sp_merge_arc(self):
         """
         Apply subgraph.merge_arc() for all subgraphs.
         """
-        subgraphs = self.sp_subgraphs
-        for label in subgraphs.keys():
-            try:
-                subgraphs[label].merge_arc()
-            except AttributeError:
-                pass
+        for label in self.sp_subgraphs:
+            subgraph = self.sp_subgraphs[label]
+            if hasattr(subgraph, "merge_arc"):
+                subgraph.merge_arc()
 
     @property
     def sp_subgraphs(self):

--- a/pyphs/graphs/subgraph.py
+++ b/pyphs/graphs/subgraph.py
@@ -7,6 +7,7 @@ Created on Sat Jun  9 12:37:43 2018
 """
 
 from pyphs.core.maths import gradient
+from pyphs.core.tools import types
 from .graph import Graph
 import sympy
 import warnings
@@ -165,7 +166,7 @@ class SubGraph(Graph):
         x = []
         for e in self.fc_storages:
             x.append(e[-1]['label'])
-        return x
+        return types.PHSVector(*x)
 
     @property
     def dxH_fc(self):
@@ -176,7 +177,7 @@ class SubGraph(Graph):
         x = []
         for e in self.ec_storages:
             x.append(e[-1]['label'])
-        return x
+        return types.PHSVector(*x)
 
     @property
     def dxH_ec(self):
@@ -187,21 +188,21 @@ class SubGraph(Graph):
         w = []
         for e in self.fc_dissipatives:
             w.append(e[-1]['label'])
-        return w
+        return types.PHSVector(*w)
 
     @property
     def w_ic(self):
         w = []
         for e in self.ic_dissipatives:
             w.append(e[-1]['label'])
-        return w
+        return types.PHSVector(*w)
 
     @property
     def w_ec(self):
         w = []
         for e in self.ec_dissipatives:
             w.append(e[-1]['label'])
-        return w
+        return types.PHSVector(*w)
 
     @property
     def z_fc(self):
@@ -234,7 +235,7 @@ class SubGraph(Graph):
             else:
                 nodes = edges_stor[0][1], edges_stor[0][0]
             # give every edges the positive direction
-            oriented_dxH_arc = self.dxH_arc
+            oriented_dxH_arc = list(self.dxH_arc)
             for i, xn in enumerate(self.x_arc):
                 if self.orientations_dic[xn] == -1:
                     oriented_dxH_arc[i] = -oriented_dxH_arc[i].subs(xn, -xn)
@@ -272,7 +273,7 @@ class SubGraph(Graph):
                 nodes = edges_diss[0][:2]
             else:
                 nodes = edges_diss[0][1], edges_diss[0][0]
-            oriented_z_arc = self.z_arc
+            oriented_z_arc = list(self.z_arc)
             for i, dic in enumerate(oriented_z_arc):
                 oriented_z_arc[i] = dic[self.anti_realizability + '_ctrl']
             for i, wn in enumerate(self.w_arc):
@@ -310,7 +311,7 @@ class SubGraph(Graph):
             else:
                 nodes = edges_stor[0][1], edges_stor[0][0]
             # give every edges the positive direction
-            oriented_dxH_rc = self.dxH_rc
+            oriented_dxH_rc = list(self.dxH_rc)
             for i, xn in enumerate(self.x_rc):
                 if self.orientations_dic[xn] == -1:
                     oriented_dxH_rc[i] = -oriented_dxH_rc[i].subs(xn, -xn)
@@ -348,7 +349,7 @@ class SubGraph(Graph):
                 nodes = edges_diss[0][:2]
             else:
                 nodes = edges_diss[0][1], edges_diss[0][0]
-            oriented_z_rc = self.z_rc
+            oriented_z_rc = list(self.z_rc)
             for i, dic in enumerate(oriented_z_rc):
                 oriented_z_rc[i] = dic[self.realizability + '_ctrl']
             for i, wn in enumerate(self.w_rc):
@@ -377,7 +378,7 @@ class SubGraph(Graph):
         return change
 
     def merge_ic_dissipatives(self):
-        edges_diss = self.ic_dissipatives
+        edges_diss = list(self.ic_dissipatives)
         change = len(edges_diss) > 1
         if change:
             # get nodes for new component
@@ -385,9 +386,8 @@ class SubGraph(Graph):
                 nodes = edges_diss[0][:2]
             else:
                 nodes = edges_diss[0][1], edges_diss[0][0]
-
             # get edges ic
-            oriented_z_ic = self.z_ic
+            oriented_z_ic = list(self.z_ic)
             for i, dic in enumerate(oriented_z_ic):
                 oriented_z_ic[i] = dic[self.realizability + '_ctrl']
             for i, wn in enumerate(self.w_ic):
@@ -396,7 +396,7 @@ class SubGraph(Graph):
             W, Zrc = realizable_merge_dissipatives(self.w_ic, oriented_z_ic)
 
             # get edges arc
-            oriented_z_ic = self.z_ic
+            oriented_z_ic = list(self.z_ic)
             for i, dic in enumerate(oriented_z_ic):
                 oriented_z_ic[i] = dic[self.anti_realizability + '_ctrl']
             for i, wn in enumerate(self.w_ic):

--- a/pyphs/misc/faust/_method_invmat.py
+++ b/pyphs/misc/faust/_method_invmat.py
@@ -51,13 +51,14 @@ class MethodInvMat(Method):
         if VERBOSE >= 2:
             print('    Build {}'.format('ud_vl'))
         ud_vl = matvecprod(-self.ijactempFll, self.Gl())
-        self.setexpr('ud_vl', list(ud_vl))
+        self.setexpr('ud_vl', types.PHSVector(*ud_vl))
 
         if VERBOSE >= 2:
             print('    Build {}'.format('Fnl'))
         temp = matvecprod(self.jactempFnll()*self.ijactempFll, self.Gl())
-        Fnl = list(types.matrix_types[0](self.Gnl()) -
-                   types.matrix_types[0](temp))
+        Fnl = types.PHSVector(*list(types.matrix_types[0](self.Gnl()) -
+                                    types.matrix_types[0](temp))
+                              )
 
         if VERBOSE >= 2:
             print('    Simplify {}'.format('jacFnlnl'))
@@ -74,8 +75,8 @@ class MethodInvMat(Method):
         if VERBOSE >= 2:
             print('    Build {} for Faust code generation'.format('ud_vnl'))
         ud_vnl = list(sympy.simplify(types.matrix_types[0](self.vnl()) -
-                      types.matrix_types[0]((matvecprod(ijacFnlnl, Fnl)))))
-        self.setexpr('ud_vnl', list(ud_vnl))
+                                     types.matrix_types[0]((matvecprod(ijacFnlnl, Fnl)))))
+        self.setexpr('ud_vnl', types.PHSVector(*ud_vnl))
 
         self.init_funcs()
 

--- a/pyphs/misc/latex/netlist.py
+++ b/pyphs/misc/latex/netlist.py
@@ -27,8 +27,8 @@ def netlist2tex(netlist):
         for comp in netlist:
             l += 1
             latex_line = r"$\ell_" + str(l) + r"$"
-            latex_dic = str(comp['dictionary'])
-            latex_comp = str(comp['component'])
+            latex_dic = str(comp['dictionary']).replace('_','\_')
+            latex_comp = str(comp['component']).replace('_','\_')
             latex_label = str(comp['label'])
             latex_nodes = str(comp['nodes'])
             latex_args = r'$\left\{ ' + dic2array(comp['arguments']) +\

--- a/pyphs/misc/latex/tools.py
+++ b/pyphs/misc/latex/tools.py
@@ -77,6 +77,9 @@ def obj2tex(obj, label, description, symbol_names, toMatrix=True):
     ------
     string
     """
+    if isinstance(obj, list):
+        obj = types.PHSVector(*obj)
+
     obj = simplify(obj)
     if toMatrix:
         obj = types.matrix_types[0](obj)

--- a/pyphs/misc/plots/multiplots.py
+++ b/pyphs/misc/plots/multiplots.py
@@ -100,7 +100,7 @@ def multiplot(x, y, show=True, **kwargs):
     if opts['ylabels'] is None:
         opts['ylabels'] = ['', ]*nplots
     elif not len(opts['ylabels']) == nplots:
-        raise AttributeError('wrong number of y labels')
+        raise AttributeError('wrong number of y labels (got {} labels for {} axes)'.format(len(opts['ylabels']), nplots))
 
     if opts['labels'] is None:
         opts['labels'] = [None, ]*nplots

--- a/pyphs/misc/tools.py
+++ b/pyphs/misc/tools.py
@@ -44,6 +44,7 @@ def geteval(obj, attr):
 else return value.
     """
     elt = getattr(obj, attr)
+    # print('in geteval', obj, attr, elt)
     if hasattr(elt, '__call__') and not isinstance(elt, sympy.Symbol):
         return elt()
     else:

--- a/pyphs/numerics/cpp/method2cpp.py
+++ b/pyphs/numerics/cpp/method2cpp.py
@@ -53,7 +53,7 @@ def init_eval(method, name):
                         freesymbs = freesymbs.pop()
                     text = 'Missing substitution symbols: {}'.format(freesymbs)
                     raise AttributeError(text)
-            if not isinstance(sobj, (float, list)):
+            if not isinstance(sobj, method.Vector):
                 sobj = numpy.asarray(sobj.tolist(), dtype=float)
             else:
                 sobj = numpy.asarray(sobj, dtype=float)

--- a/pyphs/numerics/cpp/tools.py
+++ b/pyphs/numerics/cpp/tools.py
@@ -47,7 +47,7 @@ Return a formated string associated with the path in simu.config['path']
 
 
 def dereference(method):
-    return method.args() + [k for k in method.subscpp]
+    return method.args() + method.Vector(*[k for k in method.subscpp])
 
 
 def matrix_type(dim1, dim2):

--- a/pyphs/numerics/numerical_method/_discrete_calculus.py
+++ b/pyphs/numerics/numerical_method/_discrete_calculus.py
@@ -93,13 +93,13 @@ def gradient_theta(H, x, dx, theta=0.):
     nx = len(x)
     assert len(dx) == nx, \
         'dim(dx)={0!s} is not equal to dim(x)={1!s}'.format(len(dx), nx)
-    dxHd = gradient(H, x)
+    dxHd = list(gradient(H, x))
     subs = {}
     for i, (xi, dxi) in enumerate(zip(x, dx)):
         subs[xi] = xi+theta*dxi
     for i, dxh in enumerate(dxHd):
         dxHd[i] = dxh.subs(subs)
-    return dxHd
+    return types.PHSVector(*dxHd)
 
 
 def gradient_trapez(H, x, dx):
@@ -136,10 +136,10 @@ def gradient_trapez(H, x, dx):
     nx = len(x)
     assert len(dx) == nx, \
         'dim(dx)={0!s} is not equal to dim(x)={1!s}'.format(len(dx), nx)
-    dxHd = gradient(H, x)
+    dxHd = list(gradient(H, x))
     subs = {}
     for i, (xi, dxi) in enumerate(zip(x, dx)):
         subs[xi] = xi+dxi
     for i, dxh in enumerate(dxHd):
         dxHd[i] = 0.5*(dxh + dxh.subs(subs))
-    return dxHd
+    return types.PHSVector(*dxHd)

--- a/pyphs/numerics/tools/_evaluation.py
+++ b/pyphs/numerics/tools/_evaluation.py
@@ -48,7 +48,7 @@ class Evaluation(object):
             print('Build numerical evaluations...')
 
         self.core = core.__copy__()
-        self.core.o = list(self.core.observers.values())
+        self.core.o = core.Vector(*self.core.observers.values())
 
         self.core.substitute(selfall=True)
 
@@ -80,8 +80,13 @@ class Evaluation(object):
             setattr(self, name+'_inds', inds)
 
     def args(self):
-        return (self.core.x + self.core.dx() + self.core.w + self.core.u +
-                self.core.p + list(self.core.observers.keys()))
+        return (list(self.core.x) +
+                list(self.core.dx()) +
+                list(self.core.w) +
+                list(self.core.u) +
+                list(self.core.p) +
+                list(self.core.observers.keys())
+                )
 
     @staticmethod
     def expr_to_numeric(core, name, allargs, theano=None, vectorize=True):

--- a/pyphs/tests/JuceFxTest.py
+++ b/pyphs/tests/JuceFxTest.py
@@ -15,7 +15,7 @@ def test_method2jucefx():
 
     path = 'temp'
 
-    core.subsinverse()
+    # core.subsinverse()
 
     method = core.to_method()
 

--- a/pyphs/tests/SimulationTest.py
+++ b/pyphs/tests/SimulationTest.py
@@ -235,7 +235,7 @@ def simulation_nlcore_full():
 
     # state initialization
     # !!! must be array with shape (core.dims.x(), )
-    x0 = list(map(sympy.sympify, (0., 0., 0.)))
+    x0 = list(map(sympy.sympify, (0., 0.)))
 
     # Instantiate a pyphs.Simulation object associated with a given core
     simu = Simulation(nlcore.to_method(), config=config, inits={'x': x0})

--- a/pyphs/tutorials/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/pyphs/tutorials/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyphs/tutorials/Untitled.ipynb
+++ b/pyphs/tutorials/Untitled.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyphs import Core"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "can only concatenate list (not \"PHSVector\") to list",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-33833c4c775e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0mspring\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_Mxx\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0mspring\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_Jxy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m \u001b[0mspring\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Development/repos/pyphs/pyphs/core/core.py\u001b[0m in \u001b[0;36mpprint\u001b[0;34m(self, **settings)\u001b[0m\n\u001b[1;32m   1083\u001b[0m         b = self.Matrix(self.dtx() +\n\u001b[1;32m   1084\u001b[0m                                   \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mw\u001b[0m \u001b[0;34m+\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1085\u001b[0;31m                                   \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0my\u001b[0m \u001b[0;34m+\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1086\u001b[0m                                   self.cy)\n\u001b[1;32m   1087\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: can only concatenate list (not \"PHSVector\") to list"
+     ]
+    }
+   ],
+   "source": [
+    "# instantiate a pyphs.Core object\n",
+    "spring = Core(label='spring')\n",
+    "\n",
+    "\n",
+    "# Adding the components\n",
+    "\n",
+    "q, k = spring.symbols(['q', 'k'])  # sympy symbols\n",
+    "Hk = k*q**2/1                      # sympy expression\n",
+    "spring.add_storages(q, Hk)         # add a storage component\n",
+    "\n",
+    "uk, yk = spring.symbols(['vk', 'fk'])   # sympy symbols\n",
+    "spring.add_ports(uk, yk)                # add the ports\n",
+    "\n",
+    "# Initialize the interconnexion matrix\n",
+    "spring.init_M()\n",
+    "\n",
+    "# Step by step build of matrix M\n",
+    "spring.set_Mxx([0])\n",
+    "spring.set_Jxy([[1]])\n",
+    "spring.pprint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wR, R = RL.symbols(['wR', 'R'])    # sympy symbols\n",
+    "zR = R*wR                          # sympy expression\n",
+    "RL.add_dissipations(wR, zR)        # add a dissipation component\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyphs/tutorials/core.py
+++ b/pyphs/tutorials/core.py
@@ -3,122 +3,61 @@
 from pyphs import Core
 import sympy
 
-""" 1) THE RL CORE """
+# instantiate a pyphs.Core object
+spring = Core(label='spring')
+# Adding the components
+q, k = spring.symbols(['q', 'k'])  # sympy symbols
+Hk = k*q**2/2                      # sympy expression
+spring.add_storages(q, Hk)         # add a storage component
+uk, yk = spring.symbols(['vk', 'fk'])   # sympy symbols
+spring.add_ports(uk, yk)                # add the ports
+# Step by step build of matrix M
+spring.set_Mxx([0])
+spring.set_Jxy([[1]])
+# spring.pprint()
+
 
 # instantiate a pyphs.Core object
-RL = Core(label='my_core')
-
-
+mass = Core(label='mass')
 # Adding the components
-
-xL, L = RL.symbols(['xL', 'L'])    # sympy symbols
-HL = xL**2/(2*L)                   # sympy expression
-RL.add_storages(xL, HL)            # add a storage component
-
-wR, R = RL.symbols(['wR', 'R'])    # sympy symbols
-zR = R*wR                          # sympy expression
-RL.add_dissipations(wR, zR)        # add a dissipation component
-
-u1, y1, u2, y2 = RL.symbols(['v1', 'i1', 'v2', 'i2'])   # sympy symbols
-RL.add_ports([u1, u2], [y1, y2])                        # add the ports
-
-# Initialize the interconnexion matrix
-RL.init_M()
-
+p, m = spring.symbols(['p', 'm'])  # sympy symbols
+Hm = p**2/(2*m)                      # sympy expression
+mass.add_storages(p, Hm)         # add a storage component
+um, ym = mass.symbols(['fm', 'vm'])   # sympy symbols
+mass.add_ports(um, ym)                # add the ports
 # Step by step build of matrix M
-RL.set_Mxx([0])
-RL.set_Jxw([[-1]])
-RL.set_Jxy([[-1, -1]])
+mass.set_Mxx([0])
+mass.set_Jxy([[-1]])
+# mass.pprint()
 
-# print('Two-ports RL circuit PHS:')
-# RL.pprint()
+massspring = mass + spring
+# massspring.pprint()
 
-''' 2) THE MKA CORE '''
+massspring.add_connector((0, 1))
+massspring.connect()
+# massspring.pprint()
 
-MKA = Core()
+w, a = massspring.symbols(['w', 'a'])  # sympy symbols
+z = a*w                            # sympy expression
+massspring.add_dissipations(w, z)  # add a storage component
+# massspring.pprint()
 
-# Define all symbols
-xK, K, xM, M, wA, A, u3, v3 = MKA.symbols(['xK', 'K',
-                                           'xM', 'M',
-                                           'wA', 'A',
-                                           'f3', 'v3'])
+massspring.set_Jxw([[-1.0], [0.0]])
+# massspring.pprint()
 
-# Define the constitutive laws
-HK = (xK**2)*(K/2)
-HM = (xM**2)/(2*M)
-zA = wA*A
-
-# Add all the components
-MKA.add_storages([xK, xM], HK + HM)
-MKA.add_dissipations(wA, zA)
-MKA.add_ports(u3, v3)
-
-# Initialize the interconnexion matrix
-MKA.init_M()
-
-# It is possible to define M at once with a sympy.SparseMatrix
-MKA.M = sympy.SparseMatrix([[0, 1, 0, 0], [-1, 0, -1, -1],
-                            [0, 1, 0, 0], [0, 1, 0, 0]])
-
-#print('Mass-spring-damper PHS:')
-#MKA.pprint()
-
-""" 3) CONNECTION OF RL AND MKA """
-
-#Additionate both cores
-core = RL + MKA
+massspring.reduce_z()
+# massspring.pprint()
 
 
-# Define the symbol BL for the electromechanical connection
-BL = core.symbols('BL')
-
-# Add the connector between the port #1 of RL and the port #3 of MKA
-core.add_connector((core.y.index(RL.y[1]), core.y.index(MKA.y[0])), alpha = BL)
-
-# Apply the connector
-core.connect()
-
-#print('Thiele-Small PHS:')
-#core.pprint()
-
-# Reduce the linear dissipative part
-core.reduce_z()
-
-#print('z-reduced Thiele-Small PHS:')
-#core.pprint()
+core = massspring.__copy__()
+core.H += (k/10)*q**4/4
+u, y = core.symbols(['fin', 'vout'])    # sympy symbols
+core.add_ports(u, y)                    # add the ports
+core.set_Jxy([[-1.0], [0.0]])           # define gain
+core.move_storage(0,1)
+# core.pprint()
 
 
-# Physical parameters
-L_value = 11e-3     #11mH
-R_value = 5.7   # 5.7 Ohm
-K_value = 4e7 # N/m
-M_value = 0.019 # 19g
-A_value = 0.406 #Ns/m
-BL_value = 2.99 #V/A
-
-subs = {L: L_value,
-        R: R_value,
-        K: K_value,
-        M: M_value,
-        A: A_value,
-        BL:BL_value
-       }
-
-core.subs.update(subs)
-
-# Define the new expression
-B = core.symbols('B')
-BLnl = B*sympy.exp(-((core.x[1]))**2)
-
-#Associate the expression to BL
-core.substitute(subs={BL: BLnl})
-core.subs.update({B:BL_value})
-
-# Simplify inversed symbols
-core.subsinverse()
-# Print the structure
-#print('Thiele-Small with nonlinear interconnection PHS:')
-#core.pprint()
-
-# Generate the lateX file
-#core.texwrite(path=None, title=None, authors=None, affiliations=None)
+core.subs = {m: 0.01,
+             k: 4e3,
+             a: 0.1}

--- a/test_subarrays.py
+++ b/test_subarrays.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Apr 14 16:07:13 2020
+
+@author: afalaize
+"""
+
+from pyphs import PHSMatrix, PHSSubArray, __version__, Core
+from pyphs.examples.beam_cantilever.beam_cantilever import core
+
+import sympy as sp
+import numpy as np
+
+
+N = 2
+
+A = PHSSubArray('A', array=PHSMatrix(np.eye(N)))
+B = PHSSubArray('B', array=PHSMatrix(np.eye(N)))
+J = PHSMatrix([[0, A],
+            [B, 0]])
+
+a = list()
+a_idxs = list()
+for i, e in enumerate(core.x):
+    if 'mK' in str(e):
+        a.append(e)
+        a_idxs.append(i)
+xK = PHSSubArray("xbeamK", array=a)
+
+print(xK)
+
+
+a = Core.Vector(1,2,3)
+b = Core.Vector(4,5,6)


### PR DESCRIPTION
In view of implementing variable-size subarrays for description of finite-dimensional PHS obtained from spatial discretization of distributed systems, we start by defining custom structures for vectors and matrices that comply with Sympy workflow. This should not break compatibility with current pyphs/master

The changes introduced by this PR are:

- Type of **EVERY vector quantities** (x, w, u, z, dxH, etc.) is `pyphs.core.tools.types.PHSVector` which subclasses `sympy.Tuple`. There is a convenient shortcut in `Core.Vector = pyphs.core.tools.types.PHSVector`. Note that constructor takes nargs (the vector elements): `Core.Vector(*list_of_content)`; that is, NOT `Core.Vector(list_of_content)`.
- Type of **EVERY matrix quantities** (M, J, Zl, etc.) is `pyphs.core.tools.types.PHSMatrix` which subclasses `sympy.SparseMatrix`. There is a convenient shortcut in `Core.Matrix = pyphs.core.tools.types.PHSMatrix`.